### PR TITLE
MLM-2173 adds guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^6.1|^7"
     }
 }


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2FMLM-2173)](https://netsells.atlassian.net/browse/MLM-2173)

## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging

### Problem statement
Locum upgrade to PHP8.1 and Laravel 9 requires the package to have guzzle 7 support

### Solution
Adds guzzle 7 support 

Tested & verified locally. The request was received on `netsells-x` server successfully.

### Links

JIRA: https://netsells.atlassian.net/browse/MLM-2173

## Deployment

### Migrations
No

### Environment variables
N/A

### Deployment notes
N/A